### PR TITLE
remove Main as the main nib file base name in Info.plist

### DIFF
--- a/YZSwipeBetweenViewControllerDemo/YZSwipeBetweenViewControllerDemo/Info.plist
+++ b/YZSwipeBetweenViewControllerDemo/YZSwipeBetweenViewControllerDemo/Info.plist
@@ -24,8 +24,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Theres no storyboard and with this preference the demo app crashes on startup with a runtime error
